### PR TITLE
Avoid integer wrap-around issues

### DIFF
--- a/include/range.h
+++ b/include/range.h
@@ -15,8 +15,7 @@ class Range {
         if (step_ == 0) {
             throw std::invalid_argument("Range step argument must not be zero");
         } else {
-            auto difference = stop_ - start_;
-            if ((difference < 0 && step_ > 0) || (difference > 0 && step_ < 0)) {
+            if ((start > stop && step_ > 0) || (start < stop && step_ < 0)) {
                 throw std::invalid_argument("Range arguments must result in termination");
             }
         }

--- a/test/range-tests.cpp
+++ b/test/range-tests.cpp
@@ -1,5 +1,5 @@
 #include <exception>
-
+#include <limits>
 #include <gtest/gtest.h>
 
 #include "range.h"
@@ -134,6 +134,18 @@ TEST(RangeIntegerTests, ValueZeroStepExceptionTest) {
     } catch (const std::invalid_argument& e) {
         thrown = true;
         EXPECT_EQ(std::string{"Range step argument must not be zero"},
+                  std::string{e.what()});
+    }
+    EXPECT_TRUE(thrown);
+}
+
+TEST(RangeIntegerTests, IntegerWrapAroundTest) {
+    bool thrown = false;
+    try {
+        range(int64_t{1}, std::numeric_limits<int64_t>::min(), int64_t{1});
+    } catch (const std::invalid_argument& e) {
+        thrown = true;
+        EXPECT_EQ(std::string{"Range arguments must result in termination"},
                   std::string{e.what()});
     }
     EXPECT_TRUE(thrown);


### PR DESCRIPTION
Hi!

I changed a bit the way bounds are checked for ranges. The previous method had some wrap-around issues. Doing something like "range(1, MIN_INT64, 1) was previously allowed.