### PR TITLE
Avoid integer wrap-around issues with step

### DIFF
--- a/include/range.h
+++ b/include/range.h
@@ -28,28 +28,30 @@ class Range {
         typedef T& reference;
         typedef T* pointer;
 
-        iterator(value_type value, value_type step) : value_{value}, step_{step},
-                                                      positive_step_(step_ > 0) {}
+        iterator(value_type value, value_type step, value_type boundary) : value_{value}, step_{step},
+                                                                           boundary_{boundary},
+                                                                           positive_step_(step_ > 0) {}
         iterator operator++() { value_ += step_; return *this; }
         reference operator*() { return value_; }
         const pointer operator->() { return &value_; }
-        bool operator==(const iterator& rhs) { return positive_step_ ? value_ >= rhs.value_
-                                                                     : value_ <= rhs.value_; }
-        bool operator!=(const iterator& rhs) { return positive_step_ ? value_ < rhs.value_
-                                                                     : value_ > rhs.value_; }
+        bool operator==(const iterator& rhs) { return positive_step_ ? (value_ >= rhs.value_ && value_ > boundary_)
+                                                                     : (value_ <= rhs.value_ && value_ < boundary_); }
+        bool operator!=(const iterator& rhs) { return positive_step_ ? (value_ < rhs.value_ && value_ > boundary_)
+                                                                     : (value_ > rhs.value_ && value_ < boundary_); }
         
       private:
-        const T step_;
-        const bool positive_step_;
         value_type value_;
+        const T step_;
+        const T boundary_;
+        const bool positive_step_;
     };
     
     iterator begin() const {
-        return iterator(start_, step_);
+        return iterator(start_, step_, start_);
     }
     
     iterator end() const {
-        return iterator(stop_, step_);
+        return iterator(stop_, step_, start_);
     }
   
   private:

--- a/test/range-tests.cpp
+++ b/test/range-tests.cpp
@@ -164,6 +164,30 @@ TEST(RangeIntegerTests, IntegerWrapAroundReverseTest) {
     EXPECT_TRUE(thrown);
 }
 
+TEST(RangeIntegerTests, IntegerWrapAroundStepTest) {
+    auto testRange = range(std::numeric_limits<int64_t>::min() + 1,
+                           std::numeric_limits<int64_t>::min(),
+                           int64_t{-2});
+
+    unsigned int loopCount = 0;
+    for (auto i : testRange) {
+        ++loopCount;
+        ASSERT_LE(loopCount, 1);
+    }
+}
+
+TEST(RangeIntegerTests, IntegerWrapAroundStepReverseTest) {
+    auto testRange = range(std::numeric_limits<int64_t>::max() - 1,
+                           std::numeric_limits<int64_t>::max(),
+                           int64_t{2});
+    unsigned int loopCount = 0;
+    for (auto i : testRange) {
+        ++loopCount;
+        ASSERT_LE(loopCount, 1);
+    }
+}
+
+
 TEST(RangeFloatTests, ValueStopTest) {
     for (auto stop = 0.f; stop < 100.f; ++stop) {
         auto expected = 0.f;


### PR DESCRIPTION
Hi!

I found another issue still related to integer wrap-arounds.
This time, it happens after the "step" value is added to the current value and the result wraps-around without ever reaching the "stop" value.