### PR TITLE
Make range.h work at all

### DIFF
--- a/include/range.h
+++ b/include/range.h
@@ -36,8 +36,8 @@ class Range {
         const pointer operator->() { return &value_; }
         bool operator==(const iterator& rhs) { return positive_step_ ? (value_ >= rhs.value_ && value_ > boundary_)
                                                                      : (value_ <= rhs.value_ && value_ < boundary_); }
-        bool operator!=(const iterator& rhs) { return positive_step_ ? (value_ < rhs.value_ && value_ > boundary_)
-                                                                     : (value_ > rhs.value_ && value_ < boundary_); }
+        bool operator!=(const iterator& rhs) { return positive_step_ ? (value_ < rhs.value_ && value_ >= boundary_)
+                                                                     : (value_ > rhs.value_ && value_ <= boundary_); }
         
       private:
         value_type value_;


### PR DESCRIPTION
This patch is absolutely necessary to get the code to work, it's broken as-is. The tests only actually test the initial error catching in the constructor. All the tests need to be altered to ensure that the `EXPECT_EQ()` calls are actually made, otherwise not entering the `range()` loops results in a falsely passing build.